### PR TITLE
Themes menu for Linux and OSX

### DIFF
--- a/src/menus/darwin.cson
+++ b/src/menus/darwin.cson
@@ -38,6 +38,16 @@
   }
 
   {
+    label: 'Themes'
+    submenu: [
+      { label: 'Default', command: 'application:update-theme', theme: 'default' }
+      { label: 'Dark Simple', command: 'application:update-theme', theme: 'darkSimple' }
+      { label: 'Fluttery', command: 'application:update-theme', theme: 'Fluttery.css'  }
+      { label: 'Minimalism', command: 'application:update-theme', theme: 'minimalism'}
+    ]
+  }
+
+  {
     label: 'Window'
     submenu: [
       { label: 'Minimize', accelerator: 'Command+M', selector: 'performMiniaturize:' }

--- a/src/menus/linux.cson
+++ b/src/menus/linux.cson
@@ -17,6 +17,16 @@
   }
 
   {
+    label: '&Themes'
+    submenu: [
+      { label: 'Default', command: 'application:update-theme', theme: 'default' }
+      { label: 'Dark Simple', command: 'application:update-theme', theme: 'darkSimple' }
+      { label: 'Fluttery', command: 'application:update-theme', theme: 'Fluttery.css'  }
+      { label: 'Minimalism', command: 'application:update-theme', theme: 'minimalism'}
+    ]
+  }  
+
+  {
     label: '&Help'
     submenu: [
       { label: 'Version {{ version }}', enabled: false }


### PR DESCRIPTION
Added the Themes drop-down menu to both the darwin.cson and linux.cson files, so it works on OSX and Linux.
